### PR TITLE
解决论文题目特殊符号导致无法保存

### DIFF
--- a/autoliterature/utils.py
+++ b/autoliterature/utils.py
@@ -116,6 +116,8 @@ def get_update_content(m, note_file, pdfs_path, proxy):
         
         try:
             pdf_name = '_'.join(bib['title'].split(' ')) + '.pdf'
+            # rep specific symbol with '_'
+            pdf_name = re.sub(r"[<>:\"/\\|?*\n\r\x00-\x1F\x7F']", '_', pdf_name)
             pdf_path = os.path.join(pdfs_path, pdf_name)
             
             if pdf:


### PR DESCRIPTION
解决论文标题中存在的引号或换行符导致的pdf文件无法保存